### PR TITLE
Fix for issue #209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.9
+## Bugfixes
+- #209 Fix Url helper parsing of Uri with parameters
+
 # 1.0.8
 ## Bugfixes
 - #186 Removed dead code in File class

--- a/src/Entities/Url.php
+++ b/src/Entities/Url.php
@@ -133,12 +133,16 @@ class Url
 
         if (strpos($part, '#') !== false) {
             if (strpos($part, '#') === 0) {
-                $part = substr($part, 1);
-
-                return '#'.rawurlencode($part);
+                if (substr($part, 1,1) === '!'){
+                    return '#!'.rawurlencode(substr($part, 2));
+                }
+                return '#'.rawurlencode(substr($part, 1));
             }
-            $pe = explode('#', $part);
 
+            $pe = explode('#', $part);
+            if (substr($pe[1], 0,1) === '!') {
+                return $pe[0].'/#!'.rawurlencode(substr($pe[1], 1));
+            }
             return $pe[0].'/#'.rawurlencode($pe[1]);
         }
 

--- a/tests/EntitiesTest.php
+++ b/tests/EntitiesTest.php
@@ -21,30 +21,43 @@ class EntitiesTest extends CommandTestBase
         $this->assertSame('http://www.example.com/', $url->parse(''));
         $this->assertSame('http://www.example.com/', $url->parse('/'));
 
+        $this->assertSame('http://www.example.com/?abc=123&def=456', $url->parse('?abc=123&def=456'));
+        $this->assertSame('http://www.example.com/?abc=123&def=456', $url->parse('/?abc=123&def=456'));
 
-        $this->assertSame('http://www.example.com/abc', $url->parse('abc'));
-        $this->assertSame('http://www.example.com/abc', $url->parse('/abc'));
+        $this->assertSame('http://www.example.com/#abc-123', $url->parse('#abc-123'));
+        $this->assertSame('http://www.example.com/#abc-123', $url->parse('/#abc-123'));
+
+        $this->assertSame('http://www.example.com/abc/', $url->parse('abc'));
+        $this->assertSame('http://www.example.com/abc/', $url->parse('/abc'));
         $this->assertSame('http://www.example.com/abc/', $url->parse('/abc/'));
 
-        $this->assertSame('http://www.example.com/abc/123', $url->parse('abc/123'));
-        $this->assertSame('http://www.example.com/abc/123', $url->parse('/abc/123'));
+        $this->assertSame('http://www.example.com/abc/123/', $url->parse('abc/123'));
+        $this->assertSame('http://www.example.com/abc/123/', $url->parse('/abc/123'));
         $this->assertSame('http://www.example.com/abc/123/', $url->parse('/abc/123/'));
 
-        $this->assertEquals('http://www.example.com/abc', $url->parse('abc/index.html'));
-        $this->assertEquals('http://www.example.com/abc/123', $url->parse('abc/123/index.html'));
+        $this->assertSame('http://www.example.com/abc/123/?abc=123&def=456', $url->parse('abc/123?abc=123&def=456'));
+        $this->assertSame('http://www.example.com/abc/123/?abc=123&def=456', $url->parse('/abc/123?abc=123&def=456'));
+        $this->assertSame('http://www.example.com/abc/123/?abc=123&def=456', $url->parse('/abc/123/?abc=123&def=456'));
+
+        $this->assertSame('http://www.example.com/abc/123/#abc-123', $url->parse('abc/123#abc-123'));
+        $this->assertSame('http://www.example.com/abc/123/#abc-123', $url->parse('/abc/123#abc-123'));
+        $this->assertSame('http://www.example.com/abc/123/#abc-123', $url->parse('/abc/123/#abc-123'));
+
+        $this->assertEquals('http://www.example.com/abc/', $url->parse('abc/index.html'));
+        $this->assertEquals('http://www.example.com/abc/123/', $url->parse('abc/123/index.html'));
         $this->assertEquals('http://www.example.com/abc/123.html', $url->parse('abc/123.html'));
 
-        $this->assertEquals('http://www.example.com/0', $url->parse(0));
+        $this->assertEquals('http://www.example.com/0/', $url->parse(0));
         $this->assertEquals('http://www.example.com/', $url->parse(null));
-        $this->assertEquals('http://www.example.com/-1', $url->parse(-1));
-        $this->assertEquals('http://www.example.com/3.33', $url->parse(3.33));
+        $this->assertEquals('http://www.example.com/-1/', $url->parse(-1));
+        $this->assertEquals('http://www.example.com/3.33/', $url->parse(3.33));
 
-        $this->assertSame('http://www.example.com/hello%20world', $url->parse('hello world'));
-        $this->assertSame('http://www.example.com/hello%20world', $url->parse('/hello world'));
+        $this->assertSame('http://www.example.com/hello%20world/', $url->parse('hello world'));
+        $this->assertSame('http://www.example.com/hello%20world/', $url->parse('/hello world'));
         $this->assertSame('http://www.example.com/hello%20world/', $url->parse('/hello world/'));
 
-        $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test', $url->parse('hello world/this is a test'));
-        $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test', $url->parse('/hello world/this is a test'));
+        $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test/', $url->parse('hello world/this is a test'));
+        $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test/', $url->parse('/hello world/this is a test'));
         $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test/', $url->parse('/hello world/this is a test/'));
 
         $this->assertSame('http://www.example.com/hello/world', $url->parse('hello/world/index.html'));

--- a/tests/EntitiesTest.php
+++ b/tests/EntitiesTest.php
@@ -31,6 +31,10 @@ class EntitiesTest extends CommandTestBase
         $this->assertSame('http://www.example.com/abc/', $url->parse('/abc'));
         $this->assertSame('http://www.example.com/abc/', $url->parse('/abc/'));
 
+        $this->assertSame('http://www.example.com/abc/#!abc', $url->parse('abc#!abc'));
+        $this->assertSame('http://www.example.com/abc/#!abc', $url->parse('/abc#!abc'));
+        $this->assertSame('http://www.example.com/abc/#!abc', $url->parse('/abc/#!abc'));
+
         $this->assertSame('http://www.example.com/abc/123/', $url->parse('abc/123'));
         $this->assertSame('http://www.example.com/abc/123/', $url->parse('/abc/123'));
         $this->assertSame('http://www.example.com/abc/123/', $url->parse('/abc/123/'));

--- a/tests/EntitiesTest.php
+++ b/tests/EntitiesTest.php
@@ -39,9 +39,17 @@ class EntitiesTest extends CommandTestBase
         $this->assertSame('http://www.example.com/abc/123/?abc=123&def=456', $url->parse('/abc/123?abc=123&def=456'));
         $this->assertSame('http://www.example.com/abc/123/?abc=123&def=456', $url->parse('/abc/123/?abc=123&def=456'));
 
+        $this->assertSame('http://www.example.com/abc/123/?abc=123+xyz&def=456+abc', $url->parse('abc/123?abc=123 xyz&def=456 abc'));
+        $this->assertSame('http://www.example.com/abc/123/?abc=123+xyz&def=456+abc', $url->parse('/abc/123?abc=123 xyz&def=456 abc'));
+        $this->assertSame('http://www.example.com/abc/123/?abc=123+xyz&def=456+abc', $url->parse('/abc/123/?abc=123 xyz&def=456 abc'));
+
         $this->assertSame('http://www.example.com/abc/123/#abc-123', $url->parse('abc/123#abc-123'));
         $this->assertSame('http://www.example.com/abc/123/#abc-123', $url->parse('/abc/123#abc-123'));
         $this->assertSame('http://www.example.com/abc/123/#abc-123', $url->parse('/abc/123/#abc-123'));
+
+        $this->assertSame('http://www.example.com/abc/123/#abc%20123', $url->parse('abc/123#abc 123'));
+        $this->assertSame('http://www.example.com/abc/123/#abc%20123', $url->parse('/abc/123#abc 123'));
+        $this->assertSame('http://www.example.com/abc/123/#abc%20123', $url->parse('/abc/123/#abc 123'));
 
         $this->assertEquals('http://www.example.com/abc/', $url->parse('abc/index.html'));
         $this->assertEquals('http://www.example.com/abc/123/', $url->parse('abc/123/index.html'));
@@ -50,7 +58,7 @@ class EntitiesTest extends CommandTestBase
         $this->assertEquals('http://www.example.com/0/', $url->parse(0));
         $this->assertEquals('http://www.example.com/', $url->parse(null));
         $this->assertEquals('http://www.example.com/-1/', $url->parse(-1));
-        $this->assertEquals('http://www.example.com/3.33/', $url->parse(3.33));
+        $this->assertEquals('http://www.example.com/3.33', $url->parse(3.33)); // 3.33 is a file named 3 with the ext 33
 
         $this->assertSame('http://www.example.com/hello%20world/', $url->parse('hello world'));
         $this->assertSame('http://www.example.com/hello%20world/', $url->parse('/hello world'));
@@ -60,7 +68,7 @@ class EntitiesTest extends CommandTestBase
         $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test/', $url->parse('/hello world/this is a test'));
         $this->assertSame('http://www.example.com/hello%20world/this%20is%20a%20test/', $url->parse('/hello world/this is a test/'));
 
-        $this->assertSame('http://www.example.com/hello/world', $url->parse('hello/world/index.html'));
+        $this->assertSame('http://www.example.com/hello/world/', $url->parse('hello/world/index.html'));
     }
 
     public function testUrlEntityThrowsException()

--- a/tests/ViewFileTraitTest.php
+++ b/tests/ViewFileTraitTest.php
@@ -97,7 +97,7 @@ class ViewFileTraitTest extends CommandTestBase
             __DIR__ . '/mocks/TestExcerptFile.md', ['site' => ['url' => 'http://www.example.com']]
         );
 
-        $this->assertEquals('http://www.example.com/testexcerptfile', $viewFile->getUrl());
+        $this->assertEquals('http://www.example.com/testexcerptfile/', $viewFile->getUrl());
 
         $viewFile->getFile()->setData(['permalink' => '/folder1/folder2/folder3/test.html']);
         $this->assertEquals('http://www.example.com/folder1/folder2/folder3/test.html', $viewFile->getUrl());


### PR DESCRIPTION
This pull request fixes #209 by modifying the url helper's functionality to correctly parse uri strings and encode with `rawurlencode` or `urlencode` as appropriate.